### PR TITLE
[responseManager] Pass empty arrays back from base response

### DIFF
--- a/src/responseManager.ts
+++ b/src/responseManager.ts
@@ -22,11 +22,7 @@ function baseResponse(response: AxiosResponse) {
   const data = response.data
   const results = data.results
 
-  if (!Array.isArray(results) || !results.length) {
-    return null
-  } else {
-    return results
-  }
+  return results
 }
 
 function partnerResponse(partner: AxiosResponse): PartnerResponse {
@@ -37,7 +33,7 @@ function partnerResponse(partner: AxiosResponse): PartnerResponse {
     partnerSlug: null
   }
 
-  if (results != null) {
+  if (results != null && results.length > 0) {
     response.empty = false
     response.partnerName = results[0].name
     response.partnerSlug = results[0].slug
@@ -53,7 +49,7 @@ function businessResponse(business: AxiosResponse): BusinessResponse {
     businessExternalId: null
   }
 
-  if (results != null) {
+  if (results != null && results.length > 0) {
     response.empty = false
     response.businessExternalId = results[0].external_id
   }
@@ -70,7 +66,7 @@ function offerCollectionResponse(
     approvalAmount: null
   }
 
-  if (results != null) {
+  if (results != null && results.length > 0) {
     const openCollection = results.filter((element) => element.open)
     if (!openCollection.length) {
       return response
@@ -110,7 +106,7 @@ function cashAdvanceResponse(cashAdvance: AxiosResponse): CashAdvanceResponse {
     verified: null
   }
 
-  if (results != null) {
+  if (results != null && results.length > 0) {
     const outstandingAdvances = results.filter(
       (element) => element.state === 'outstanding'
     )
@@ -127,8 +123,8 @@ function cashAdvanceResponse(cashAdvance: AxiosResponse): CashAdvanceResponse {
     response.acceptedAmount = cashAdvance.amount
     response.outstandingAmount = String(outstandingAmount)
     response.paidAmount = cashAdvance.paid_amount
-    ;(response.estimatedPayoffDate = cashAdvance.estimated_repayment_date),
-      (response.verified = cashAdvance.verified)
+    response.estimatedPayoffDate = cashAdvance.estimated_repayment_date
+    response.verified = cashAdvance.verified
   }
 
   return response
@@ -142,11 +138,10 @@ function optInResponse(optIn: AxiosResponse): OptInResponse {
   }
 
   if (results != null) {
+    response.empty = false
     if (results.length > 0) {
-      response.empty = false
       response.opted = true
     } else {
-      response.empty = false
       response.opted = false
     }
   }

--- a/src/responseManager.ts
+++ b/src/responseManager.ts
@@ -67,7 +67,7 @@ function offerCollectionResponse(
   }
 
   if (results != null && results.length > 0) {
-    const openCollection = results.filter((element) => element.open)
+    const openCollection = results.filter((element: any) => element.open)
     if (!openCollection.length) {
       return response
     }
@@ -108,7 +108,7 @@ function cashAdvanceResponse(cashAdvance: AxiosResponse): CashAdvanceResponse {
 
   if (results != null && results.length > 0) {
     const outstandingAdvances = results.filter(
-      (element) => element.state === 'outstanding'
+      (element: any) => element.state === 'outstanding'
     )
     if (!outstandingAdvances.length) {
       return response


### PR DESCRIPTION
## Description of the change

> We were down-casting empty arrays into null at the base response level which was needed by some high-level functions as part of the response. 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Cleanup
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Test

- [ ] Unit Test
- [ ] Tested in Dev/Local
- [ ] Tested in Prod
