### PR TITLE
Add id fields for partner and business

### DIFF
--- a/src/ParafinClient.ts
+++ b/src/ParafinClient.ts
@@ -78,13 +78,13 @@ class Client {
       .then(returnOrThrow)
   }
 
-  async partners(): Promise<Ok<PartnerResponse, ParafinError>> {
+  async partner(): Promise<Ok<PartnerResponse, ParafinError>> {
     return get('partners', this.config)
       .andThen(partnerResponse)
       .then(returnOrThrow)
   }
 
-  async businessCores(): Promise<Ok<BusinessCoreResponse, ParafinError>> {
+  async businessCore(): Promise<Ok<BusinessCoreResponse, ParafinError>> {
     return get('businesses/core', this.config)
       .andThen(businessCoreResponse)
       .then(returnOrThrow)

--- a/src/responseManager.ts
+++ b/src/responseManager.ts
@@ -45,11 +45,13 @@ function partnerResponse(
 ): ResultAsync<PartnerResponse, ParafinError> {
   const results = baseResponse(partner)
   const response: PartnerResponse = {
+    partnerId: null,
     partnerName: null,
     partnerSlug: null
   }
 
   if (results != null && results.length > 0) {
+    response.partnerId = results[0].id
     response.partnerName = results[0].name
     response.partnerSlug = results[0].slug
   }
@@ -62,10 +64,12 @@ function businessCoreResponse(
 ): ResultAsync<BusinessCoreResponse, ParafinError> {
   const results = baseResponse(businessCore)
   const response: BusinessCoreResponse = {
+    businessId: null,
     externalId: null
   }
 
   if (results != null && results.length > 0) {
+    response.businessId = results[0].id
     response.externalId = results[0].external_id
   }
 
@@ -206,7 +210,9 @@ function parafinResponse(
 ): ResultAsync<ParafinResponse, ParafinError> {
   const response: ParafinResponse = {
     opted: null,
+    businessId: null,
     externalId: null,
+    partnerId: null,
     partnerName: null,
     partnerSlug: null,
     approvalAmount: null,
@@ -220,6 +226,7 @@ function parafinResponse(
 
   mergedResultAsync[0].then((res) => {
     if (res.isOk()) {
+      response.partnerId = res.value.partnerId
       response.partnerName = res.value.partnerName
       response.partnerSlug = res.value.partnerSlug
     }
@@ -227,6 +234,7 @@ function parafinResponse(
 
   mergedResultAsync[1].then((res) => {
     if (res.isOk()) {
+      response.businessId = res.value.businessId
       response.externalId = res.value.externalId
     }
   })

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,11 +1,13 @@
 export interface BasicResponse {}
 
 export interface PartnerResponse extends BasicResponse {
+  partnerId: string | null
   partnerName: string | null
   partnerSlug: string | null
 }
 
 export interface BusinessCoreResponse extends BasicResponse {
+  businessId: string | null
   externalId: string | null
 }
 


### PR DESCRIPTION
## Description of the change

Tested on `partners()` and `businessCore()` endpoints:

```
{
  partnerId: 'f18f51bc-4537-4fbf-ba54-8c22f55270a4',
  partnerName: 'Mindbody',
  partnerSlug: 'mindbody'
}

{
  businessId: 'd77c00ab-cb55-4e5e-bd0b-e1c9b0ecc8c2',
  externalId: 'amici001'
}
```

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Cleanup
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Test

- [ ] Unit Test
- [x] Tested in Dev/Local
- [ ] Tested in Prod